### PR TITLE
remove meaningless  statements in TON Stake contracts

### DIFF
--- a/contracts/stake/StakeSimple.sol
+++ b/contracts/stake/StakeSimple.sol
@@ -90,10 +90,6 @@ contract StakeSimple is Stake1Storage, AccessibleCommon, IStakeSimple {
 
         LibTokenStake1.StakedAmount storage staked = userStaked[msg.sender];
         require(!staked.released, "StakeSimple: Already withdraw");
-        require(
-            staked.releasedAmount <= staked.amount,
-            "StakeSimple: Amount wrong"
-        );
 
         staked.released = true;
         staked.releasedBlock = block.number;

--- a/contracts/stake/StakeTON.sol
+++ b/contracts/stake/StakeTON.sol
@@ -121,14 +121,12 @@ contract StakeTON is TokamakStaker, IStakeTON {
 
             tonWithdraw(ton, wton, tonAmount, wtonAmount, tosAmount);
         } else if (paytoken == address(0)) {
-            require(staked.releasedAmount <= amount, "StakeTON: Amount wrong");
             staked.releasedAmount = amount;
             address payable self = address(uint160(address(this)));
             require(self.balance >= amount, "StakeTON: insuffient ETH");
             (bool success, ) = msg.sender.call{value: amount}("");
             require(success, "StakeTON: withdraw failed.");
         } else {
-            require(staked.releasedAmount <= amount, "StakeTON: Amount wrong");
             staked.releasedAmount = amount;
             require(
                 IIERC20(paytoken).transfer(msg.sender, amount),

--- a/contracts/stake/StakeTONUpgrade3.sol
+++ b/contracts/stake/StakeTONUpgrade3.sol
@@ -178,20 +178,12 @@ contract StakeTONUpgrade3 is StakeTONStorage, AccessibleCommon {
             );
 
         } else if (paytoken == address(0)) {
-            require(
-                staked.releasedAmount <= amount,
-                "StakeTONUpgrade3: Amount wrong"
-            );
             staked.releasedAmount = amount;
             address payable self = address(uint160(address(this)));
             require(self.balance >= amount, "StakeTONUpgrade3: insuffient ETH");
             (bool success, ) = msg.sender.call{value: amount}("");
             require(success, "StakeTONUpgrade3: withdraw failed.");
         } else {
-            require(
-                staked.releasedAmount <= amount,
-                "StakeTONUpgrade3: Amount wrong"
-            );
             staked.releasedAmount = amount;
             require(
                 ITOS3(paytoken).transfer(msg.sender, amount),


### PR DESCRIPTION
`staked.releasedAmount <= amount` 조건을 확인하는 require 구문이 아래 이유로 의미가 없는 것으로 분석되어 제거합니다.

1. 분할해서 withdraw 하는 기능이 존재하지 않기 때문에 staked.releasedAmount > amount가 되는 상황이 발생하지 않음.
2. staked.releasedAmount는 항상 staked.amount로 초기화되고, staked.released flag로 인해 withdraw 함수를 1회 이상 호출하는게 불가능함.